### PR TITLE
fix: add explicit hooks/lspServers refs to plugin manifests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Each plugin is a self-contained directory with this structure:
 ```
 <plugin-name>/
 ├── .claude-plugin/
-│   └── plugin.json      # Plugin metadata (name, version, author)
+│   └── plugin.json      # Plugin metadata + refs to hooks/lspServers
 ├── .lsp.json            # LSP server configuration
 └── hooks/
     ├── hooks.json       # Hook definitions (runs on SessionStart)
@@ -38,7 +38,9 @@ Auto-install scripts that run on session start. Pattern:
 ## Adding a New Plugin
 
 1. Create a new directory with the plugin name
-2. Add `.claude-plugin/plugin.json` with name, description, version, author
+2. Add `.claude-plugin/plugin.json` with name, description, version, author, and refs:
+   - `"hooks": "./hooks/hooks.json"`
+   - `"lspServers": "./.lsp.json"`
 3. Add `.lsp.json` with command and extensionToLanguage mapping
 4. Add `hooks/hooks.json` to run auto-install on SessionStart
 5. Add `hooks/check-<name>.sh` auto-install script

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A collection of Language Server Protocol (LSP) plugins for [Claude Code](https:/
 > [!IMPORTANT]
 > Requires Claude Code 2.0.74+
 
+> [!WARNING] > **Known Issue:** LSP integration is broken in versions ~2.0.69 through 2.0.76+. Root cause is a race condition where LSP Manager initializes before plugins finish loading ([#14803](https://github.com/anthropics/claude-code/issues/14803), [#13952](https://github.com/anthropics/claude-code/issues/13952)). PRs are in flight to fix this. Workaround: downgrade to v2.0.67 and set `ENABLE_LSP_TOOL=1`.
+
 The Language Server Protocol provides IDE-like intelligence to Claude Code. On startup, Claude Code automatically starts LSP servers from installed plugins and exposes them to Claude in two ways:
 
 **LSP Tool** - A builtin tool with 5 operations mapping directly to LSP commands:
@@ -23,20 +25,20 @@ The Language Server Protocol provides IDE-like intelligence to Claude Code. On s
 
 ## Available Plugins
 
-| Plugin                                             | Language              | LSP                                                                      |
-| -------------------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
-| [gopls](./gopls)                                   | Go                    | [gopls](https://github.com/golang/tools/tree/master/gopls)               |
-| [vtsls](./vtsls)                                   | TypeScript/JavaScript | [vtsls](https://github.com/yioneko/vtsls)                                |
-| [pyright](./pyright)                               | Python                | [pyright](https://github.com/microsoft/pyright)                          |
-| [jdtls](./jdtls)                                   | Java                  | [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)                 |
-| [clangd](./clangd)                                 | C/C++                 | [clangd](https://clangd.llvm.org/)                                       |
-| [omnisharp](./omnisharp)                           | C#                    | [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn)               |
-| [intelephense](./intelephense)                     | PHP                   | [Intelephense](https://github.com/bmewburn/intelephense-docs)            |
-| [kotlin-language-server](./kotlin-language-server) | Kotlin                | [kotlin-language-server](https://github.com/fwcd/kotlin-language-server) |
-| [rust-analyzer](./rust-analyzer)                   | Rust                  | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)              |
-| [solargraph](./solargraph)                         | Ruby                  | [Solargraph](https://github.com/castwide/solargraph)                     |
+| Plugin                                             | Language              | LSP                                                                           |
+| -------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------- |
+| [gopls](./gopls)                                   | Go                    | [gopls](https://github.com/golang/tools/tree/master/gopls)                    |
+| [vtsls](./vtsls)                                   | TypeScript/JavaScript | [vtsls](https://github.com/yioneko/vtsls)                                     |
+| [pyright](./pyright)                               | Python                | [pyright](https://github.com/microsoft/pyright)                               |
+| [jdtls](./jdtls)                                   | Java                  | [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)                      |
+| [clangd](./clangd)                                 | C/C++                 | [clangd](https://clangd.llvm.org/)                                            |
+| [omnisharp](./omnisharp)                           | C#                    | [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn)                    |
+| [intelephense](./intelephense)                     | PHP                   | [Intelephense](https://github.com/bmewburn/intelephense-docs)                 |
+| [kotlin-language-server](./kotlin-language-server) | Kotlin                | [kotlin-language-server](https://github.com/fwcd/kotlin-language-server)      |
+| [rust-analyzer](./rust-analyzer)                   | Rust                  | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)                   |
+| [solargraph](./solargraph)                         | Ruby                  | [Solargraph](https://github.com/castwide/solargraph)                          |
 | [vscode-html-css](./vscode-html-css)               | HTML/CSS              | [vscode-langservers](https://github.com/hrsh7th/vscode-langservers-extracted) |
-| [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | [Dart SDK](https://dart.dev/tools/dart-analyze)                          |
+| [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | [Dart SDK](https://dart.dev/tools/dart-analyze)                               |
 
 ## Getting Started
 
@@ -265,18 +267,18 @@ The `.lsp.json` file configures the language server:
 
 **Optional Fields**
 
-| Field                   | Type     | Description                                                     |
-| ----------------------- | -------- | --------------------------------------------------------------- |
-| `args`                  | string[] | Arguments passed to the command                                 |
-| `transport`             | string   | Communication method: `"stdio"` (default) or `"socket"`         |
-| `env`                   | object   | Environment variables to set when starting the server           |
-| `initializationOptions` | object   | Options passed during LSP initialization                        |
-| `settings`              | object   | Server-specific settings via `workspace/didChangeConfiguration` |
-| `workspaceFolder`       | string   | Workspace folder path for the server                            |
-| `startupTimeout`        | number   | Max time to wait for server startup (milliseconds)              |
-| `shutdownTimeout`       | number   | Max time to wait for graceful shutdown (milliseconds)           |
-| `restartOnCrash`        | boolean  | Whether to automatically restart the server if it crashes       |
-| `maxRestarts`           | number   | Max restart attempts before giving up (default: 3)              |
+| Field                   | Type     | Description                                                       |
+| ----------------------- | -------- | ----------------------------------------------------------------- |
+| `args`                  | string[] | Arguments passed to the command                                   |
+| `transport`             | string   | Communication method: `"stdio"` (default) or `"socket"`           |
+| `env`                   | object   | Environment variables to set when starting the server             |
+| `initializationOptions` | object   | Options passed during LSP initialization                          |
+| `settings`              | object   | Server-specific settings via `workspace/didChangeConfiguration`   |
+| `workspaceFolder`       | string   | Workspace folder path for the server                              |
+| `startupTimeout`        | number   | Max time to wait for server startup (milliseconds)                |
+| `shutdownTimeout`       | number   | Max time to wait for graceful shutdown (milliseconds)             |
+| `restartOnCrash`        | boolean  | Whether to automatically restart the server if it crashes         |
+| `maxRestarts`           | number   | Max restart attempts before giving up (default: 3)                |
 | `loggingConfig`         | object   | Debug logging configuration (see [Debug Logging](#debug-logging)) |
 
 </details>
@@ -292,6 +294,9 @@ The `.lsp.json` file configures the language server:
     "command": "gopls",
     "extensionToLanguage": {
       ".go": "go"
+    },
+    "loggingConfig": {
+      "args": ["-rpc.trace", "-logfile", "${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }
@@ -306,7 +311,9 @@ The `.lsp.json` file configures the language server:
   "version": "1.0.0",
   "author": {
     "name": "Your Name"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }
 ```
 
@@ -346,13 +353,13 @@ Logs are written to `~/.claude/debug/`.
 
 **Plugins with logging pre-configured:**
 
-| Plugin | Method |
-|--------|--------|
-| gopls | `-rpc.trace` + logfile |
-| clangd | `--log=verbose` |
-| omnisharp | `-v` verbose flag |
+| Plugin        | Method                       |
+| ------------- | ---------------------------- |
+| gopls         | `-rpc.trace` + logfile       |
+| clangd        | `--log=verbose`              |
+| omnisharp     | `-v` verbose flag            |
 | rust-analyzer | `RA_LOG` + `RA_LOG_FILE` env |
-| solargraph | `SOLARGRAPH_LOG` env |
+| solargraph    | `SOLARGRAPH_LOG` env         |
 | dart-analyzer | `--instrumentation-log-file` |
 
 **Not supported** (use LSP trace settings instead): vtsls, pyright, jdtls, intelephense, kotlin-language-server, vscode-html-css

--- a/clangd/.claude-plugin/plugin.json
+++ b/clangd/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/dart-analyzer/.claude-plugin/plugin.json
+++ b/dart-analyzer/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/gopls/.claude-plugin/plugin.json
+++ b/gopls/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/intelephense/.claude-plugin/plugin.json
+++ b/intelephense/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/jdtls/.claude-plugin/plugin.json
+++ b/jdtls/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/kotlin-language-server/.claude-plugin/plugin.json
+++ b/kotlin-language-server/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/omnisharp/.claude-plugin/plugin.json
+++ b/omnisharp/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/pyright/.claude-plugin/plugin.json
+++ b/pyright/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/rust-analyzer/.claude-plugin/plugin.json
+++ b/rust-analyzer/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/solargraph/.claude-plugin/plugin.json
+++ b/solargraph/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/vscode-html-css/.claude-plugin/plugin.json
+++ b/vscode-html-css/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }

--- a/vtsls/.claude-plugin/plugin.json
+++ b/vtsls/.claude-plugin/plugin.json
@@ -4,5 +4,7 @@
   "version": "1.0.0",
   "author": {
     "name": "Jan Kott"
-  }
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
 }


### PR DESCRIPTION
## Summary
- Add explicit `hooks` and `lspServers` fields to all plugin.json files per the plugin manifest schema
- Add warning banner to README about known LSP race condition issue (#14803, #13952)
- Update CLAUDE.md to document the new plugin.json structure

## Test plan
- [ ] Verify plugins still load correctly with explicit refs
- [ ] Check README warning renders properly on GitHub