### PR TITLE
feat: add Swift language server plugin (sourcekit-lsp)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -138,7 +138,18 @@
       "category": "development",
       "tags": ["dart", "flutter", "lsp"],
       "author": {
-        "name": "Tyler Jewell"
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "sourcekit-lsp",
+      "version": "1.0.0",
+      "source": "./sourcekit-lsp",
+      "description": "Swift language server",
+      "category": "development",
+      "tags": ["swift", "ios", "macos", "lsp"],
+      "author": {
+        "name": "Jan Kott"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The Language Server Protocol provides IDE-like intelligence to Claude Code. On s
 | [solargraph](./solargraph)                         | Ruby                  | [Solargraph](https://github.com/castwide/solargraph)                          |
 | [vscode-html-css](./vscode-html-css)               | HTML/CSS              | [vscode-langservers](https://github.com/hrsh7th/vscode-langservers-extracted) |
 | [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | [Dart SDK](https://dart.dev/tools/dart-analyze)                               |
+| [sourcekit-lsp](./sourcekit-lsp)                   | Swift                 | [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp)                   |
 
 ## Getting Started
 
@@ -70,6 +71,7 @@ Install individual plugins:
 /plugin install solargraph@claude-code-lsps
 /plugin install vscode-html-css@claude-code-lsps
 /plugin install dart-analyzer@claude-code-lsps
+/plugin install sourcekit-lsp@claude-code-lsps
 ```
 
 Or browse and install interactively:
@@ -224,6 +226,20 @@ Or install Flutter (includes Dart):
 ```
 
 Ensure `dart` is in your PATH.
+
+</details>
+
+<details>
+<summary><strong>Swift (sourcekit-lsp)</strong></summary>
+
+sourcekit-lsp is bundled with Xcode. Install Xcode from the App Store:
+
+```bash
+# Verify installation
+xcrun --find sourcekit-lsp
+```
+
+Or install a Swift toolchain from [swift.org/install](https://swift.org/install/).
 
 </details>
 

--- a/sourcekit-lsp/.claude-plugin/plugin.json
+++ b/sourcekit-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "sourcekit-lsp",
+  "description": "Swift language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/sourcekit-lsp/.lsp.json
+++ b/sourcekit-lsp/.lsp.json
@@ -1,0 +1,9 @@
+{
+  "swift": {
+    "command": "xcrun",
+    "args": ["sourcekit-lsp"],
+    "extensionToLanguage": {
+      ".swift": "swift"
+    }
+  }
+}

--- a/sourcekit-lsp/hooks/check-sourcekit-lsp.sh
+++ b/sourcekit-lsp/hooks/check-sourcekit-lsp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if sourcekit-lsp is available via xcrun (bundled with Xcode)
+
+if xcrun --find sourcekit-lsp &> /dev/null; then
+    # sourcekit-lsp is available, exit silently
+    exit 0
+fi
+
+# Check if Xcode Command Line Tools are installed
+if ! xcode-select -p &> /dev/null; then
+    echo "[sourcekit-lsp] Xcode Command Line Tools not installed."
+    echo "                Install Xcode from the App Store, or run:"
+    echo "                xcode-select --install"
+    exit 0
+fi
+
+# Xcode tools installed but sourcekit-lsp not found
+echo "[sourcekit-lsp] sourcekit-lsp not found."
+echo "                Install Xcode from the App Store or download a Swift toolchain from:"
+echo "                https://swift.org/install/"
+
+exit 0

--- a/sourcekit-lsp/hooks/hooks.json
+++ b/sourcekit-lsp/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for sourcekit-lsp installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-sourcekit-lsp.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add sourcekit-lsp plugin for Swift language support
- Uses `xcrun sourcekit-lsp` (bundled with Xcode)
- Auto-install hook guides users to install Xcode or Swift toolchain if not found

## Test plan
- [ ] Install plugin via `/plugin install sourcekit-lsp@claude-code-lsps`
- [ ] Verify LSP starts on opening `.swift` files
- [ ] Test go-to-definition and hover on Swift symbols