### PR TITLE
feat: add 6 new LSP plugins and sort all entries A-Z

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,45 +10,12 @@
   },
   "plugins": [
     {
-      "name": "gopls",
+      "name": "bash-language-server",
       "version": "1.0.0",
-      "source": "./gopls",
-      "description": "Go language server",
+      "source": "./bash-language-server",
+      "description": "Bash language server",
       "category": "development",
-      "tags": ["go", "lsp"],
-      "author": {
-        "name": "Jan Kott"
-      }
-    },
-    {
-      "name": "vtsls",
-      "version": "1.0.0",
-      "source": "./vtsls",
-      "description": "TypeScript/JavaScript language server",
-      "category": "development",
-      "tags": ["typescript", "javascript", "lsp"],
-      "author": {
-        "name": "Jan Kott"
-      }
-    },
-    {
-      "name": "pyright",
-      "version": "1.0.0",
-      "source": "./pyright",
-      "description": "Python language server",
-      "category": "development",
-      "tags": ["python", "lsp"],
-      "author": {
-        "name": "Jan Kott"
-      }
-    },
-    {
-      "name": "jdtls",
-      "version": "1.0.0",
-      "source": "./jdtls",
-      "description": "Java language server",
-      "category": "development",
-      "tags": ["java", "lsp"],
+      "tags": ["bash", "shell", "sh", "zsh", "lsp"],
       "author": {
         "name": "Jan Kott"
       }
@@ -65,12 +32,34 @@
       }
     },
     {
-      "name": "omnisharp",
+      "name": "dart-analyzer",
       "version": "1.0.0",
-      "source": "./omnisharp",
-      "description": "C# language server",
+      "source": "./dart-analyzer",
+      "description": "Dart/Flutter language server",
       "category": "development",
-      "tags": ["csharp", "dotnet", "lsp"],
+      "tags": ["dart", "flutter", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "elixir-ls",
+      "version": "1.0.0",
+      "source": "./elixir-ls",
+      "description": "Elixir language server",
+      "category": "development",
+      "tags": ["elixir", "erlang", "beam", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "gopls",
+      "version": "1.0.0",
+      "source": "./gopls",
+      "description": "Go language server",
+      "category": "development",
+      "tags": ["go", "lsp"],
       "author": {
         "name": "Jan Kott"
       }
@@ -87,12 +76,56 @@
       }
     },
     {
+      "name": "jdtls",
+      "version": "1.0.0",
+      "source": "./jdtls",
+      "description": "Java language server",
+      "category": "development",
+      "tags": ["java", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
       "name": "kotlin-language-server",
       "version": "1.0.0",
       "source": "./kotlin-language-server",
       "description": "Kotlin language server",
       "category": "development",
       "tags": ["kotlin", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "lua-language-server",
+      "version": "1.0.0",
+      "source": "./lua-language-server",
+      "description": "Lua language server",
+      "category": "development",
+      "tags": ["lua", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "omnisharp",
+      "version": "1.0.0",
+      "source": "./omnisharp",
+      "description": "C# language server",
+      "category": "development",
+      "tags": ["csharp", "dotnet", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "pyright",
+      "version": "1.0.0",
+      "source": "./pyright",
+      "description": "Python language server",
+      "category": "development",
+      "tags": ["python", "lsp"],
       "author": {
         "name": "Jan Kott"
       }
@@ -120,6 +153,28 @@
       }
     },
     {
+      "name": "sourcekit-lsp",
+      "version": "1.0.0",
+      "source": "./sourcekit-lsp",
+      "description": "Swift language server",
+      "category": "development",
+      "tags": ["swift", "ios", "macos", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "terraform-ls",
+      "version": "1.0.0",
+      "source": "./terraform-ls",
+      "description": "Terraform language server",
+      "category": "development",
+      "tags": ["terraform", "hcl", "devops", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
       "name": "vscode-html-css",
       "version": "1.0.0",
       "source": "./vscode-html-css",
@@ -131,23 +186,34 @@
       }
     },
     {
-      "name": "dart-analyzer",
+      "name": "vtsls",
       "version": "1.0.0",
-      "source": "./dart-analyzer",
-      "description": "Dart/Flutter language server",
+      "source": "./vtsls",
+      "description": "TypeScript/JavaScript language server",
       "category": "development",
-      "tags": ["dart", "flutter", "lsp"],
+      "tags": ["typescript", "javascript", "lsp"],
       "author": {
         "name": "Jan Kott"
       }
     },
     {
-      "name": "sourcekit-lsp",
+      "name": "yaml-language-server",
       "version": "1.0.0",
-      "source": "./sourcekit-lsp",
-      "description": "Swift language server",
+      "source": "./yaml-language-server",
+      "description": "YAML language server",
       "category": "development",
-      "tags": ["swift", "ios", "macos", "lsp"],
+      "tags": ["yaml", "yml", "lsp"],
+      "author": {
+        "name": "Jan Kott"
+      }
+    },
+    {
+      "name": "zls",
+      "version": "1.0.0",
+      "source": "./zls",
+      "description": "Zig language server",
+      "category": "development",
+      "tags": ["zig", "lsp"],
       "author": {
         "name": "Jan Kott"
       }

--- a/README.md
+++ b/README.md
@@ -29,21 +29,27 @@ The Language Server Protocol provides IDE-like intelligence to Claude Code. On s
 
 ## Available Plugins
 
-| Plugin                                             | Language              | LSP                                                                           |
-| -------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------- |
-| [gopls](./gopls)                                   | Go                    | [gopls](https://github.com/golang/tools/tree/master/gopls)                    |
-| [vtsls](./vtsls)                                   | TypeScript/JavaScript | [vtsls](https://github.com/yioneko/vtsls)                                     |
-| [pyright](./pyright)                               | Python                | [pyright](https://github.com/microsoft/pyright)                               |
-| [jdtls](./jdtls)                                   | Java                  | [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)                      |
-| [clangd](./clangd)                                 | C/C++                 | [clangd](https://clangd.llvm.org/)                                            |
-| [omnisharp](./omnisharp)                           | C#                    | [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn)                    |
-| [intelephense](./intelephense)                     | PHP                   | [Intelephense](https://github.com/bmewburn/intelephense-docs)                 |
-| [kotlin-language-server](./kotlin-language-server) | Kotlin                | [kotlin-language-server](https://github.com/fwcd/kotlin-language-server)      |
-| [rust-analyzer](./rust-analyzer)                   | Rust                  | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)                   |
-| [solargraph](./solargraph)                         | Ruby                  | [Solargraph](https://github.com/castwide/solargraph)                          |
-| [vscode-html-css](./vscode-html-css)               | HTML/CSS              | [vscode-langservers](https://github.com/hrsh7th/vscode-langservers-extracted) |
-| [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | [Dart SDK](https://dart.dev/tools/dart-analyze)                               |
-| [sourcekit-lsp](./sourcekit-lsp)                   | Swift                 | [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp)                   |
+| Plugin                                             | Language              | Extensions                                  | LSP                                                                              |
+| -------------------------------------------------- | --------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- |
+| [bash-language-server](./bash-language-server)     | Bash/Shell            | `.sh` `.bash` `.zsh` `.ksh`                 | [bash-language-server](https://github.com/bash-lsp/bash-language-server)         |
+| [clangd](./clangd)                                 | C/C++                 | `.c` `.h` `.cpp` `.hpp` `.cc` `.cxx` `.hxx` | [clangd](https://clangd.llvm.org/)                                               |
+| [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | `.dart`                                     | [Dart SDK](https://dart.dev/tools/dart-analyze)                                  |
+| [elixir-ls](./elixir-ls)                           | Elixir                | `.ex` `.exs`                                | [elixir-ls](https://github.com/elixir-lsp/elixir-ls)                             |
+| [gopls](./gopls)                                   | Go                    | `.go`                                       | [gopls](https://github.com/golang/tools/tree/master/gopls)                       |
+| [intelephense](./intelephense)                     | PHP                   | `.php` `.phtml`                             | [Intelephense](https://github.com/bmewburn/intelephense-docs)                    |
+| [jdtls](./jdtls)                                   | Java                  | `.java`                                     | [jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)                         |
+| [kotlin-language-server](./kotlin-language-server) | Kotlin                | `.kt` `.kts`                                | [kotlin-language-server](https://github.com/fwcd/kotlin-language-server)         |
+| [lua-language-server](./lua-language-server)       | Lua                   | `.lua`                                      | [lua-language-server](https://github.com/LuaLS/lua-language-server)              |
+| [omnisharp](./omnisharp)                           | C#                    | `.cs` `.csx`                                | [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn)                       |
+| [pyright](./pyright)                               | Python                | `.py` `.pyi`                                | [pyright](https://github.com/microsoft/pyright)                                  |
+| [rust-analyzer](./rust-analyzer)                   | Rust                  | `.rs`                                       | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)                      |
+| [solargraph](./solargraph)                         | Ruby                  | `.rb` `.rake` `.gemspec`                    | [Solargraph](https://github.com/castwide/solargraph)                             |
+| [sourcekit-lsp](./sourcekit-lsp)                   | Swift                 | `.swift`                                    | [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp)                      |
+| [terraform-ls](./terraform-ls)                     | Terraform             | `.tf` `.tfvars`                             | [terraform-ls](https://github.com/hashicorp/terraform-ls)                        |
+| [vscode-html-css](./vscode-html-css)               | HTML/CSS              | `.html` `.htm` `.css` `.scss` `.less`       | [vscode-langservers](https://github.com/hrsh7th/vscode-langservers-extracted)    |
+| [vtsls](./vtsls)                                   | TypeScript/JavaScript | `.ts` `.tsx` `.js` `.jsx` `.mjs` `.cjs`     | [vtsls](https://github.com/yioneko/vtsls)                                        |
+| [yaml-language-server](./yaml-language-server)     | YAML                  | `.yaml` `.yml`                              | [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) |
+| [zls](./zls)                                       | Zig                   | `.zig` `.zon`                               | [zls](https://github.com/zigtools/zls)                                           |
 
 ## Getting Started
 
@@ -59,19 +65,25 @@ claude
 Install individual plugins:
 
 ```bash
-/plugin install gopls@claude-code-lsps
-/plugin install vtsls@claude-code-lsps
-/plugin install pyright@claude-code-lsps
-/plugin install jdtls@claude-code-lsps
+/plugin install bash-language-server@claude-code-lsps
 /plugin install clangd@claude-code-lsps
-/plugin install omnisharp@claude-code-lsps
+/plugin install dart-analyzer@claude-code-lsps
+/plugin install elixir-ls@claude-code-lsps
+/plugin install gopls@claude-code-lsps
 /plugin install intelephense@claude-code-lsps
+/plugin install jdtls@claude-code-lsps
 /plugin install kotlin-language-server@claude-code-lsps
+/plugin install lua-language-server@claude-code-lsps
+/plugin install omnisharp@claude-code-lsps
+/plugin install pyright@claude-code-lsps
 /plugin install rust-analyzer@claude-code-lsps
 /plugin install solargraph@claude-code-lsps
-/plugin install vscode-html-css@claude-code-lsps
-/plugin install dart-analyzer@claude-code-lsps
 /plugin install sourcekit-lsp@claude-code-lsps
+/plugin install terraform-ls@claude-code-lsps
+/plugin install vscode-html-css@claude-code-lsps
+/plugin install vtsls@claude-code-lsps
+/plugin install yaml-language-server@claude-code-lsps
+/plugin install zls@claude-code-lsps
 ```
 
 Or browse and install interactively:
@@ -87,44 +99,17 @@ Or browse and install interactively:
 Each plugin will attempt to auto-install its LSP server on first use. If auto-install fails, use the manual instructions below.
 
 <details>
-<summary><strong>Go (gopls)</strong></summary>
+<summary><strong>Bash/Shell (bash-language-server)</strong></summary>
 
 ```bash
-go install golang.org/x/tools/gopls@latest
+brew install bash-language-server
 ```
 
-Ensure `~/go/bin` is in your PATH.
-
-</details>
-
-<details>
-<summary><strong>TypeScript/JavaScript (vtsls)</strong></summary>
+Or via npm:
 
 ```bash
-npm install -g @vtsls/language-server typescript
+npm install -g bash-language-server
 ```
-
-</details>
-
-<details>
-<summary><strong>Python (pyright)</strong></summary>
-
-```bash
-pip install pyright
-```
-
-</details>
-
-<details>
-<summary><strong>Java (jdtls)</strong></summary>
-
-```bash
-brew install jdtls
-```
-
-Or download manually from [Eclipse JDT Language Server](http://download.eclipse.org/jdtls/snapshots/).
-
-Requires Java 21+ runtime.
 
 </details>
 
@@ -159,57 +144,6 @@ dotnet tool install -g csharp-ls
 </details>
 
 <details>
-<summary><strong>PHP (intelephense)</strong></summary>
-
-```bash
-npm install -g intelephense
-```
-
-</details>
-
-<details>
-<summary><strong>Kotlin (kotlin-language-server)</strong></summary>
-
-```bash
-brew install kotlin-language-server
-```
-
-</details>
-
-<details>
-<summary><strong>Rust (rust-analyzer)</strong></summary>
-
-```bash
-brew install rust-analyzer
-```
-
-Or via rustup:
-
-```bash
-rustup component add rust-analyzer
-```
-
-</details>
-
-<details>
-<summary><strong>Ruby (solargraph)</strong></summary>
-
-```bash
-gem install solargraph
-```
-
-</details>
-
-<details>
-<summary><strong>HTML/CSS (vscode-html-css)</strong></summary>
-
-```bash
-npm install -g vscode-langservers-extracted
-```
-
-</details>
-
-<details>
 <summary><strong>Dart/Flutter (dart-analyzer)</strong></summary>
 
 Install Dart SDK:
@@ -230,6 +164,116 @@ Ensure `dart` is in your PATH.
 </details>
 
 <details>
+<summary><strong>Elixir (elixir-ls)</strong></summary>
+
+```bash
+brew install elixir-ls
+```
+
+Requires Elixir to be installed:
+
+```bash
+brew install elixir
+```
+
+</details>
+
+<details>
+<summary><strong>Go (gopls)</strong></summary>
+
+```bash
+go install golang.org/x/tools/gopls@latest
+```
+
+Ensure `~/go/bin` is in your PATH.
+
+</details>
+
+<details>
+<summary><strong>HTML/CSS (vscode-html-css)</strong></summary>
+
+```bash
+npm install -g vscode-langservers-extracted
+```
+
+</details>
+
+<details>
+<summary><strong>Java (jdtls)</strong></summary>
+
+```bash
+brew install jdtls
+```
+
+Or download manually from [Eclipse JDT Language Server](http://download.eclipse.org/jdtls/snapshots/).
+
+Requires Java 21+ runtime.
+
+</details>
+
+<details>
+<summary><strong>Kotlin (kotlin-language-server)</strong></summary>
+
+```bash
+brew install kotlin-language-server
+```
+
+</details>
+
+<details>
+<summary><strong>Lua (lua-language-server)</strong></summary>
+
+```bash
+brew install lua-language-server
+```
+
+Or download from [GitHub releases](https://github.com/LuaLS/lua-language-server/releases).
+
+</details>
+
+<details>
+<summary><strong>PHP (intelephense)</strong></summary>
+
+```bash
+npm install -g intelephense
+```
+
+</details>
+
+<details>
+<summary><strong>Python (pyright)</strong></summary>
+
+```bash
+pip install pyright
+```
+
+</details>
+
+<details>
+<summary><strong>Ruby (solargraph)</strong></summary>
+
+```bash
+gem install solargraph
+```
+
+</details>
+
+<details>
+<summary><strong>Rust (rust-analyzer)</strong></summary>
+
+```bash
+brew install rust-analyzer
+```
+
+Or via rustup:
+
+```bash
+rustup component add rust-analyzer
+```
+
+</details>
+
+<details>
 <summary><strong>Swift (sourcekit-lsp)</strong></summary>
 
 sourcekit-lsp is bundled with Xcode. Install Xcode from the App Store:
@@ -240,6 +284,52 @@ xcrun --find sourcekit-lsp
 ```
 
 Or install a Swift toolchain from [swift.org/install](https://swift.org/install/).
+
+</details>
+
+<details>
+<summary><strong>Terraform (terraform-ls)</strong></summary>
+
+```bash
+brew install terraform-ls
+```
+
+Or download from [GitHub releases](https://github.com/hashicorp/terraform-ls/releases).
+
+</details>
+
+<details>
+<summary><strong>TypeScript/JavaScript (vtsls)</strong></summary>
+
+```bash
+npm install -g @vtsls/language-server typescript
+```
+
+</details>
+
+<details>
+<summary><strong>YAML (yaml-language-server)</strong></summary>
+
+```bash
+brew install yaml-language-server
+```
+
+Or via npm:
+
+```bash
+npm install -g yaml-language-server
+```
+
+</details>
+
+<details>
+<summary><strong>Zig (zls)</strong></summary>
+
+```bash
+brew install zls
+```
+
+Requires Zig to be installed. Download from [ziglang.org](https://ziglang.org/download/).
 
 </details>
 

--- a/bash-language-server/.claude-plugin/plugin.json
+++ b/bash-language-server/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "bash-language-server",
+  "description": "Bash language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/bash-language-server/.lsp.json
+++ b/bash-language-server/.lsp.json
@@ -1,0 +1,12 @@
+{
+  "bash": {
+    "command": "bash-language-server",
+    "args": ["start"],
+    "extensionToLanguage": {
+      ".sh": "shellscript",
+      ".bash": "shellscript",
+      ".zsh": "shellscript",
+      ".ksh": "shellscript"
+    }
+  }
+}

--- a/bash-language-server/hooks/check-bash-language-server.sh
+++ b/bash-language-server/hooks/check-bash-language-server.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if bash-language-server is installed and available in PATH
+
+if command -v bash-language-server &> /dev/null; then
+    exit 0
+fi
+
+# Try brew first
+if command -v brew &> /dev/null; then
+    echo "[bash-language-server] Installing via Homebrew..."
+    brew install bash-language-server
+
+    if command -v bash-language-server &> /dev/null; then
+        echo "[bash-language-server] Installed successfully"
+    else
+        echo "[bash-language-server] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+# Try npm
+if command -v npm &> /dev/null; then
+    echo "[bash-language-server] Installing via npm..."
+    npm install -g bash-language-server
+
+    if command -v bash-language-server &> /dev/null; then
+        echo "[bash-language-server] Installed successfully"
+    else
+        echo "[bash-language-server] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+echo "[bash-language-server] Not installed. Install via:"
+echo "                       brew install bash-language-server"
+echo "                       npm install -g bash-language-server"
+
+exit 0

--- a/bash-language-server/hooks/hooks.json
+++ b/bash-language-server/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for bash-language-server installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-bash-language-server.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/elixir-ls/.claude-plugin/plugin.json
+++ b/elixir-ls/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "elixir-ls",
+  "description": "Elixir language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/elixir-ls/.lsp.json
+++ b/elixir-ls/.lsp.json
@@ -1,0 +1,9 @@
+{
+  "elixir": {
+    "command": "elixir-ls",
+    "extensionToLanguage": {
+      ".ex": "elixir",
+      ".exs": "elixir"
+    }
+  }
+}

--- a/elixir-ls/hooks/check-elixir-ls.sh
+++ b/elixir-ls/hooks/check-elixir-ls.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Check if elixir-ls is installed and available in PATH
+
+if command -v elixir-ls &> /dev/null; then
+    exit 0
+fi
+
+# Check if elixir is installed (required for elixir-ls to be useful)
+if ! command -v elixir &> /dev/null; then
+    echo "[elixir-ls] Elixir is not installed. Please install Elixir first:"
+    echo "            brew install elixir"
+    echo "            Or see: https://elixir-lang.org/install.html"
+    exit 0
+fi
+
+# Try brew
+if command -v brew &> /dev/null; then
+    echo "[elixir-ls] Installing via Homebrew..."
+    brew install elixir-ls
+
+    if command -v elixir-ls &> /dev/null; then
+        echo "[elixir-ls] Installed successfully"
+    else
+        echo "[elixir-ls] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+echo "[elixir-ls] Not installed. Install via:"
+echo "            brew install elixir-ls"
+echo ""
+echo "            Or see: https://github.com/elixir-lsp/elixir-ls"
+
+exit 0

--- a/elixir-ls/hooks/hooks.json
+++ b/elixir-ls/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for elixir-ls installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-elixir-ls.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lua-language-server/.claude-plugin/plugin.json
+++ b/lua-language-server/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "lua-language-server",
+  "description": "Lua language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/lua-language-server/.lsp.json
+++ b/lua-language-server/.lsp.json
@@ -1,0 +1,8 @@
+{
+  "lua": {
+    "command": "lua-language-server",
+    "extensionToLanguage": {
+      ".lua": "lua"
+    }
+  }
+}

--- a/lua-language-server/hooks/check-lua-language-server.sh
+++ b/lua-language-server/hooks/check-lua-language-server.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check if lua-language-server is installed and available in PATH
+
+if command -v lua-language-server &> /dev/null; then
+    # lua-language-server is installed, exit silently
+    exit 0
+fi
+
+# Check if brew is available
+if command -v brew &> /dev/null; then
+    echo "[lua-language-server] Installing via Homebrew..."
+    brew install lua-language-server
+
+    if command -v lua-language-server &> /dev/null; then
+        echo "[lua-language-server] Installed successfully"
+    else
+        echo "[lua-language-server] Installation may have succeeded but binary not in PATH"
+        echo "                      Try restarting your terminal"
+    fi
+    exit 0
+fi
+
+# No brew available
+echo "[lua-language-server] Not installed. Install via Homebrew:"
+echo "                      brew install lua-language-server"
+echo ""
+echo "                      Or download from: https://github.com/LuaLS/lua-language-server/releases"
+
+exit 0

--- a/lua-language-server/hooks/hooks.json
+++ b/lua-language-server/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for lua-language-server installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-lua-language-server.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/terraform-ls/.claude-plugin/plugin.json
+++ b/terraform-ls/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "terraform-ls",
+  "description": "Terraform language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/terraform-ls/.lsp.json
+++ b/terraform-ls/.lsp.json
@@ -1,0 +1,10 @@
+{
+  "terraform": {
+    "command": "terraform-ls",
+    "args": ["serve"],
+    "extensionToLanguage": {
+      ".tf": "terraform",
+      ".tfvars": "terraform-vars"
+    }
+  }
+}

--- a/terraform-ls/hooks/check-terraform-ls.sh
+++ b/terraform-ls/hooks/check-terraform-ls.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if terraform-ls is installed and available in PATH
+
+if command -v terraform-ls &> /dev/null; then
+    exit 0
+fi
+
+# Try brew
+if command -v brew &> /dev/null; then
+    echo "[terraform-ls] Installing via Homebrew..."
+    brew install terraform-ls
+
+    if command -v terraform-ls &> /dev/null; then
+        echo "[terraform-ls] Installed successfully"
+    else
+        echo "[terraform-ls] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+echo "[terraform-ls] Not installed. Install via:"
+echo "               brew install terraform-ls"
+echo ""
+echo "               Or download from: https://github.com/hashicorp/terraform-ls/releases"
+
+exit 0

--- a/terraform-ls/hooks/hooks.json
+++ b/terraform-ls/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for terraform-ls installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-terraform-ls.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/yaml-language-server/.claude-plugin/plugin.json
+++ b/yaml-language-server/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "yaml-language-server",
+  "description": "YAML language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/yaml-language-server/.lsp.json
+++ b/yaml-language-server/.lsp.json
@@ -1,0 +1,10 @@
+{
+  "yaml": {
+    "command": "yaml-language-server",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".yaml": "yaml",
+      ".yml": "yaml"
+    }
+  }
+}

--- a/yaml-language-server/hooks/check-yaml-language-server.sh
+++ b/yaml-language-server/hooks/check-yaml-language-server.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if yaml-language-server is installed and available in PATH
+
+if command -v yaml-language-server &> /dev/null; then
+    exit 0
+fi
+
+# Try brew first
+if command -v brew &> /dev/null; then
+    echo "[yaml-language-server] Installing via Homebrew..."
+    brew install yaml-language-server
+
+    if command -v yaml-language-server &> /dev/null; then
+        echo "[yaml-language-server] Installed successfully"
+    else
+        echo "[yaml-language-server] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+# Try npm
+if command -v npm &> /dev/null; then
+    echo "[yaml-language-server] Installing via npm..."
+    npm install -g yaml-language-server
+
+    if command -v yaml-language-server &> /dev/null; then
+        echo "[yaml-language-server] Installed successfully"
+    else
+        echo "[yaml-language-server] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+echo "[yaml-language-server] Not installed. Install via:"
+echo "                       brew install yaml-language-server"
+echo "                       npm install -g yaml-language-server"
+
+exit 0

--- a/yaml-language-server/hooks/hooks.json
+++ b/yaml-language-server/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for yaml-language-server installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-yaml-language-server.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/zls/.claude-plugin/plugin.json
+++ b/zls/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "zls",
+  "description": "Zig language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Jan Kott"
+  },
+  "hooks": "./hooks/hooks.json",
+  "lspServers": "./.lsp.json"
+}

--- a/zls/.lsp.json
+++ b/zls/.lsp.json
@@ -1,0 +1,9 @@
+{
+  "zig": {
+    "command": "zls",
+    "extensionToLanguage": {
+      ".zig": "zig",
+      ".zon": "zig"
+    }
+  }
+}

--- a/zls/hooks/check-zls.sh
+++ b/zls/hooks/check-zls.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check if zls is installed and available in PATH
+
+if command -v zls &> /dev/null; then
+    exit 0
+fi
+
+# Check if zig is installed (required for zls to be useful)
+if ! command -v zig &> /dev/null; then
+    echo "[zls] Zig is not installed. Please install Zig first from https://ziglang.org/download/"
+    exit 0
+fi
+
+# Try brew
+if command -v brew &> /dev/null; then
+    echo "[zls] Installing via Homebrew..."
+    brew install zls
+
+    if command -v zls &> /dev/null; then
+        echo "[zls] Installed successfully"
+    else
+        echo "[zls] Installation may have succeeded but binary not in PATH"
+    fi
+    exit 0
+fi
+
+echo "[zls] Not installed. Install via:"
+echo "      brew install zls"
+echo ""
+echo "      Or download from: https://github.com/zigtools/zls/releases"
+
+exit 0

--- a/zls/hooks/hooks.json
+++ b/zls/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for zls installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-zls.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add 6 new LSP plugins: bash-language-server, lua-language-server, yaml-language-server, terraform-ls, zls (Zig), elixir-ls
- Add Extensions column to Available Plugins table in README
- Sort all plugin listings alphabetically (A-Z) in README and marketplace.json

## New Plugins
| Plugin | Language | Extensions |
|--------|----------|------------|
| bash-language-server | Bash/Shell | `.sh` `.bash` `.zsh` `.ksh` |
| lua-language-server | Lua | `.lua` |
| yaml-language-server | YAML | `.yaml` `.yml` |
| terraform-ls | Terraform | `.tf` `.tfvars` |
| zls | Zig | `.zig` `.zon` |
| elixir-ls | Elixir | `.ex` `.exs` |

## Test plan
- [ ] Install each new plugin via `/plugin install <name>@claude-code-lsps`
- [ ] Verify LSP starts on opening files with corresponding extensions
- [ ] Test go-to-definition and hover functionality