### PR TITLE
feat: add 6 new LSP plugins, debug logging, and sort A-Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,16 +463,21 @@ Logs are written to `~/.claude/debug/`.
 
 **Plugins with logging pre-configured:**
 
-| Plugin        | Method                       |
-| ------------- | ---------------------------- |
-| gopls         | `-rpc.trace` + logfile       |
-| clangd        | `--log=verbose`              |
-| omnisharp     | `-v` verbose flag            |
-| rust-analyzer | `RA_LOG` + `RA_LOG_FILE` env |
-| solargraph    | `SOLARGRAPH_LOG` env         |
-| dart-analyzer | `--instrumentation-log-file` |
+| Plugin                 | Method                             |
+| ---------------------- | ---------------------------------- |
+| bash-language-server   | `BASH_IDE_LOG_LEVEL` env           |
+| clangd                 | `--log=verbose`                    |
+| dart-analyzer          | `--instrumentation-log-file`       |
+| gopls                  | `-rpc.trace` + logfile             |
+| lua-language-server    | `--loglevel=trace` + `--logpath`   |
+| omnisharp              | `-v` verbose flag                  |
+| rust-analyzer          | `RA_LOG` + `RA_LOG_FILE` env       |
+| solargraph             | `SOLARGRAPH_LOG` env               |
+| sourcekit-lsp          | `--log-level debug`                |
+| terraform-ls           | `TF_LOG` + `TF_LOG_PATH` env       |
+| zls                    | `--log-level` + `--log-file`       |
 
-**Not supported** (use LSP trace settings instead): vtsls, pyright, jdtls, intelephense, kotlin-language-server, vscode-html-css
+**Not supported** (use LSP trace settings instead): elixir-ls, intelephense, jdtls, kotlin-language-server, pyright, vscode-html-css, vtsls, yaml-language-server
 
 ## License
 

--- a/bash-language-server/.lsp.json
+++ b/bash-language-server/.lsp.json
@@ -7,6 +7,11 @@
       ".bash": "shellscript",
       ".zsh": "shellscript",
       ".ksh": "shellscript"
+    },
+    "loggingConfig": {
+      "env": {
+        "BASH_IDE_LOG_LEVEL": "debug"
+      }
     }
   }
 }

--- a/dart-analyzer/.lsp.json
+++ b/dart-analyzer/.lsp.json
@@ -1,7 +1,7 @@
 {
   "dart": {
     "command": "dart",
-    "args": ["language-server", "--client-id=claude-code.dart-analyzer", "--client-version=1.0.0"],
+    "args": ["language-server"],
     "extensionToLanguage": {
       ".dart": "dart"
     },

--- a/lua-language-server/.lsp.json
+++ b/lua-language-server/.lsp.json
@@ -3,6 +3,9 @@
     "command": "lua-language-server",
     "extensionToLanguage": {
       ".lua": "lua"
+    },
+    "loggingConfig": {
+      "args": ["--loglevel=trace", "--logpath=${CLAUDE_PLUGIN_LSP_LOG_DIR}"]
     }
   }
 }

--- a/sourcekit-lsp/.lsp.json
+++ b/sourcekit-lsp/.lsp.json
@@ -4,6 +4,9 @@
     "args": ["sourcekit-lsp"],
     "extensionToLanguage": {
       ".swift": "swift"
+    },
+    "loggingConfig": {
+      "args": ["--log-level", "debug"]
     }
   }
 }

--- a/terraform-ls/.lsp.json
+++ b/terraform-ls/.lsp.json
@@ -5,6 +5,12 @@
     "extensionToLanguage": {
       ".tf": "terraform",
       ".tfvars": "terraform-vars"
+    },
+    "loggingConfig": {
+      "env": {
+        "TF_LOG": "DEBUG",
+        "TF_LOG_PATH": "${CLAUDE_PLUGIN_LSP_LOG_FILE}"
+      }
     }
   }
 }

--- a/zls/.lsp.json
+++ b/zls/.lsp.json
@@ -4,6 +4,9 @@
     "extensionToLanguage": {
       ".zig": "zig",
       ".zon": "zig"
+    },
+    "loggingConfig": {
+      "args": ["--log-level=debug", "--log-file=${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add 6 new LSP plugins: bash-language-server, lua-language-server, yaml-language-server, terraform-ls, zls (Zig), elixir-ls
- Add Extensions column to Available Plugins table in README
- Sort all plugin listings alphabetically (A-Z) in README and marketplace.json
- Add debug logging support for 5 additional plugins (11 total now supported)
- Remove unnecessary telemetry flags from dart-analyzer

## New Plugins
| Plugin | Language | Extensions |
|--------|----------|------------|
| bash-language-server | Bash/Shell | `.sh` `.bash` `.zsh` `.ksh` |
| lua-language-server | Lua | `.lua` |
| yaml-language-server | YAML | `.yaml` `.yml` |
| terraform-ls | Terraform | `.tf` `.tfvars` |
| zls | Zig | `.zig` `.zon` |
| elixir-ls | Elixir | `.ex` `.exs` |

## Debug Logging Added
| Plugin | Method |
|--------|--------|
| bash-language-server | `BASH_IDE_LOG_LEVEL` env |
| lua-language-server | `--loglevel=trace` + `--logpath` |
| sourcekit-lsp | `--log-level debug` |
| terraform-ls | `TF_LOG` + `TF_LOG_PATH` env |
| zls | `--log-level` + `--log-file` |

## Test plan
- [ ] Install each new plugin via `/plugin install <name>@claude-code-lsps`
- [ ] Verify LSP starts on opening files with corresponding extensions
- [ ] Test debug logging with `claude --enable-lsp-logging`