### PR TITLE
feat: add Objective-C/Objective-C++ support to clangd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Language Server Protocol provides IDE-like intelligence to Claude Code. On s
 | Plugin                                             | Language              | Extensions                                  | LSP                                                                              |
 | -------------------------------------------------- | --------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- |
 | [bash-language-server](./bash-language-server)     | Bash/Shell            | `.sh` `.bash` `.zsh` `.ksh`                 | [bash-language-server](https://github.com/bash-lsp/bash-language-server)         |
-| [clangd](./clangd)                                 | C/C++                 | `.c` `.h` `.cpp` `.hpp` `.cc` `.cxx` `.hxx` | [clangd](https://clangd.llvm.org/)                                               |
+| [clangd](./clangd)                                 | C/C++/Objective-C     | `.c` `.h` `.cpp` `.hpp` `.cc` `.cxx` `.hxx` `.m` `.mm` | [clangd](https://clangd.llvm.org/)                                               |
 | [clojure-lsp](./clojure-lsp)                       | Clojure               | `.clj` `.cljs` `.cljc` `.edn`               | [clojure-lsp](https://github.com/clojure-lsp/clojure-lsp)                        |
 | [dart-analyzer](./dart-analyzer)                   | Dart/Flutter          | `.dart`                                     | [Dart SDK](https://dart.dev/tools/dart-analyze)                                  |
 | [elixir-ls](./elixir-ls)                           | Elixir                | `.ex` `.exs`                                | [elixir-ls](https://github.com/elixir-lsp/elixir-ls)                             |
@@ -120,7 +120,7 @@ npm install -g bash-language-server
 </details>
 
 <details>
-<summary><strong>C/C++ (clangd)</strong></summary>
+<summary><strong>C/C++/Objective-C (clangd)</strong></summary>
 
 ```bash
 brew install llvm
@@ -131,6 +131,8 @@ Or via Xcode Command Line Tools:
 ```bash
 xcode-select --install
 ```
+
+Supports C, C++, Objective-C (.m), and Objective-C++ (.mm) files.
 
 </details>
 

--- a/clangd/.lsp.json
+++ b/clangd/.lsp.json
@@ -8,7 +8,9 @@
       ".hpp": "cpp",
       ".cc": "cpp",
       ".cxx": "cpp",
-      ".hxx": "cpp"
+      ".hxx": "cpp",
+      ".m": "objective-c",
+      ".mm": "objective-cpp"
     },
     "loggingConfig": {
       "args": ["--log=verbose"]


### PR DESCRIPTION
## Summary
- Add Objective-C (.m) and Objective-C++ (.mm) file support to clangd plugin
- Update README documentation

## Changes
- Added `.m` extension mapping to `objective-c` language ID
- Added `.mm` extension mapping to `objective-cpp` language ID
- Updated README table and manual installation section

## Background
clangd is based on the Clang compiler and has native support for Objective-C languages. This change exposes that functionality through the LSP plugin.

Closes #20

## Test plan
- [ ] Verify .m files are recognized by clangd
- [ ] Verify .mm files are recognized by clangd
- [ ] Check LSP features work with Objective-C code