### PR TITLE
docs: update LSP status and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug Report
+about: Report an issue with an LSP plugin
+title: '[PLUGIN_NAME] Brief description of the issue'
+labels: bug
+assignees: ''
+---
+
+## Plugin Information
+**Plugin name:** (e.g., gopls, pyright, rust-analyzer)
+**Plugin version:** (from `/plugin` in Claude Code)
+
+## Environment
+**Claude Code version:** (run `claude --version` or check in UI)
+**Operating System:** (macOS, Linux, Windows)
+**LSP server version:** (e.g., `gopls version`, `pyright --version`)
+
+## Checklist
+Please confirm you have completed the following before submitting:
+
+- [ ] I am using Claude Code v2.1.0 or later (LSP is broken in v2.0.69-v2.0.x)
+- [ ] I checked the **Plugins tab** in Claude Code (`/plugin`) for errors
+- [ ] I verified the LSP server is installed according to [Manual Installation](https://github.com/boostvolt/claude-code-lsps#manual-lsp-installation) instructions
+- [ ] I verified the LSP binary is in my PATH (e.g., `which gopls`, `which pyright`)
+- [ ] I checked Claude Code logs at `~/.claude/debug/` (if `--enable-lsp-logging` was used)
+
+## Description
+A clear description of what the issue is.
+
+## Steps to Reproduce
+1. Open a file with extension `.ext`
+2. Try to use LSP feature (e.g., go to definition)
+3. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Error Messages
+```
+Paste any error messages from:
+- Claude Code UI
+- Plugins tab in Claude Code (/plugin)
+- Claude Code logs (~/.claude/debug/)
+```
+
+## Additional Context
+Add any other context, screenshots, or configuration details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Claude Code Issues
+    url: https://github.com/anthropics/claude-code/issues
+    about: Report issues with Claude Code itself (not LSP plugins)
+  - name: Manual Installation
+    url: https://github.com/boostvolt/claude-code-lsps#manual-lsp-installation
+    about: Installation instructions for all LSP servers

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Request a new LSP plugin or feature enhancement
+title: '[REQUEST] Brief description'
+labels: enhancement
+assignees: ''
+---
+
+## Request Type
+- [ ] New LSP plugin for a language
+- [ ] Enhancement to existing plugin
+- [ ] Documentation improvement
+
+## Language/Plugin Information
+**Language name:** (e.g., Haskell, Elixir, F#)
+**LSP server:** (name and link to official LSP server, e.g., https://github.com/example/language-server)
+**File extensions:** (e.g., `.hs`, `.lhs`)
+
+## Installation Command
+How is the LSP server typically installed?
+```bash
+# e.g., npm install -g language-server
+# or brew install language-server
+```
+
+## Additional Context
+- Is this LSP widely used?
+- Does it have good documentation?
+- Any special configuration requirements?
+- Are you willing to contribute a PR?

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A collection of Language Server Protocol (LSP) plugins for [Claude Code](https:/
 
 ## What is LSP Integration?
 
-> [!WARNING]
-> **Known Issue:** LSP integration is broken since ~v2.0.69. Root cause is a race condition where LSP Manager initializes before plugins finish loading ([#14803](https://github.com/anthropics/claude-code/issues/14803), [#13952](https://github.com/anthropics/claude-code/issues/13952)). PRs are in flight to fix this. Workaround: downgrade to v2.0.67 and set `ENABLE_LSP_TOOL=1`.
+> [!NOTE]
+> **LSP Integration:** If you're on v2.0.69 through v2.0.x, LSP integration is broken due to a race condition ([#14803](https://github.com/anthropics/claude-code/issues/14803), [#13952](https://github.com/anthropics/claude-code/issues/13952)). This has been fixed in v2.1.0+. Please upgrade to the latest version.
 
 The Language Server Protocol provides IDE-like intelligence to Claude Code. On startup, Claude Code automatically starts LSP servers from installed plugins and exposes them to Claude in two ways:
 


### PR DESCRIPTION
## Summary
- Update README to reflect LSP fix availability in v2.1.0+
- Add comprehensive GitHub issue templates

## Changes

### README Updates
- Changed LSP integration warning to note (fix is available)
- Updated messaging: v2.1.0+ has the race condition fix
- Removed workaround instructions (no longer needed)

### Issue Templates

**Bug Report Template:**
- Pre-submission checklist requiring users to verify:
  - Claude Code v2.1.0+ (LSP working version)
  - Plugins tab checked for errors
  - Manual installation steps followed
  - LSP binary in PATH
  - Debug logs reviewed
- Structured sections for environment, reproduction steps, error messages

**Feature Request Template:**
- For new LSP plugin requests or enhancements
- Collects language info, LSP server details, installation commands
- Asks about willingness to contribute

**Config:**
- Disables blank issues
- Links to Claude Code issues and manual installation docs

## Benefits
- Reduces issues from users on broken versions
- Ensures users verify setup before filing bugs
- Provides clear structure for actionable bug reports
- Helps filter LSP plugin issues from Claude Code issues

## Test plan
- [ ] Verify issue templates appear when creating new issue
- [ ] Check template formatting renders correctly
- [ ] Confirm config links work properly