### PR TITLE
refactor: enhance plugin metadata and remove unsupported loggingConfig

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,10 @@
   "name": "claude-code-lsps",
   "metadata": {
     "description": "LSP plugins for Claude Code",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "license": "MIT",
+    "repository": "https://github.com/boostvolt/claude-code-lsps",
+    "homepage": "https://github.com/boostvolt/claude-code-lsps"
   },
   "owner": {
     "name": "Jan Kott"
@@ -109,9 +112,9 @@
       }
     },
     {
-      "name": "kotlin-language-server",
+      "name": "kotlin-lsp",
       "version": "1.0.0",
-      "source": "./kotlin-language-server",
+      "source": "./kotlin-lsp",
       "description": "Kotlin language server",
       "category": "development",
       "tags": ["kotlin", "lsp"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@ Each plugin is a self-contained directory with this structure:
 ```
 <plugin-name>/
 ├── .claude-plugin/
-│   └── plugin.json      # Plugin metadata + refs to hooks/lspServers
-├── .lsp.json            # LSP server configuration
+│   └── plugin.json      # Plugin metadata
+├── .lsp.json            # LSP server configuration (auto-discovered)
 └── hooks/
-    ├── hooks.json       # Hook definitions (runs on SessionStart)
+    ├── hooks.json       # Hook definitions (auto-discovered, runs on SessionStart)
     └── check-<name>.sh  # Auto-install script for the LSP binary
 ```
 
@@ -38,13 +38,13 @@ Auto-install scripts that run on session start. Pattern:
 ## Adding a New Plugin
 
 1. Create a new directory with the plugin name
-2. Add `.claude-plugin/plugin.json` with name, description, version, author, and refs:
-   - `"hooks": "./hooks/hooks.json"`
-   - `"lspServers": "./.lsp.json"`
+2. Add `.claude-plugin/plugin.json` with name, description, version, and author
 3. Add `.lsp.json` with command and extensionToLanguage mapping
 4. Add `hooks/hooks.json` to run auto-install on SessionStart
 5. Add `hooks/check-<name>.sh` auto-install script
 6. Update README.md: add to Available Plugins table and Manual Installation section
+
+Note: `.lsp.json` and `hooks/hooks.json` are auto-discovered from default locations - no need to reference them in `plugin.json`.
 
 ## Debug Logging
 

--- a/README.md
+++ b/README.md
@@ -429,19 +429,18 @@ The `.lsp.json` file configures the language server:
 
 **Optional Fields**
 
-| Field                   | Type     | Description                                                       |
-| ----------------------- | -------- | ----------------------------------------------------------------- |
-| `args`                  | string[] | Arguments passed to the command                                   |
-| `transport`             | string   | Communication method: `"stdio"` (default) or `"socket"`           |
-| `env`                   | object   | Environment variables to set when starting the server             |
-| `initializationOptions` | object   | Options passed during LSP initialization                          |
-| `settings`              | object   | Server-specific settings via `workspace/didChangeConfiguration`   |
-| `workspaceFolder`       | string   | Workspace folder path for the server                              |
-| `startupTimeout`        | number   | Max time to wait for server startup (milliseconds)                |
-| `shutdownTimeout`       | number   | Max time to wait for graceful shutdown (milliseconds)             |
-| `restartOnCrash`        | boolean  | Whether to automatically restart the server if it crashes         |
-| `maxRestarts`           | number   | Max restart attempts before giving up (default: 3)                |
-| `loggingConfig`         | object   | Debug logging configuration (see [Debug Logging](#debug-logging)) |
+| Field                   | Type     | Description                                                      |
+| ----------------------- | -------- | ---------------------------------------------------------------- |
+| `args`                  | string[] | Arguments passed to the command                                  |
+| `transport`             | string   | Communication method: `"stdio"` (default) or `"socket"`          |
+| `env`                   | object   | Environment variables to set when starting the server            |
+| `initializationOptions` | object   | Options passed during LSP initialization                         |
+| `settings`              | object   | Server-specific settings via `workspace/didChangeConfiguration`  |
+| `workspaceFolder`       | string   | Workspace folder path for the server                             |
+| `startupTimeout`        | number   | Max time to wait for server startup (milliseconds)               |
+| `shutdownTimeout`       | number   | Max time to wait for graceful shutdown (milliseconds)            |
+| `restartOnCrash`        | boolean  | Whether to automatically restart the server if it crashes        |
+| `maxRestarts`           | number   | Max restart attempts before giving up (default: 3)               |
 
 </details>
 
@@ -456,9 +455,6 @@ The `.lsp.json` file configures the language server:
     "command": "gopls",
     "extensionToLanguage": {
       ".go": "go"
-    },
-    "loggingConfig": {
-      "args": ["-rpc.trace", "-logfile", "${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }
@@ -474,8 +470,8 @@ The `.lsp.json` file configures the language server:
   "author": {
     "name": "Your Name"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps"
 }
 ```
 
@@ -502,35 +498,6 @@ The `.lsp.json` file configures the language server:
 </details>
 
 ---
-
-## Debug Logging
-
-Enable verbose LSP logging by running Claude Code with `--enable-lsp-logging`:
-
-```bash
-claude --enable-lsp-logging
-```
-
-Logs are written to `~/.claude/debug/`.
-
-**Plugins with logging pre-configured:**
-
-| Plugin                 | Method                             |
-| ---------------------- | ---------------------------------- |
-| bash-language-server   | `BASH_IDE_LOG_LEVEL` env           |
-| clangd                 | `--log=verbose`                    |
-| clojure-lsp            | `--trace-level verbose`            |
-| dart-analyzer          | `--instrumentation-log-file`       |
-| gopls                  | `-rpc.trace` + logfile             |
-| lua-language-server    | `--loglevel=trace` + `--logpath`   |
-| omnisharp              | `-v` verbose flag                  |
-| rust-analyzer          | `RA_LOG` + `RA_LOG_FILE` env       |
-| solargraph             | `SOLARGRAPH_LOG` env               |
-| sourcekit-lsp          | `--log-level debug`                |
-| terraform-ls           | `TF_LOG` + `TF_LOG_PATH` env       |
-| zls                    | `--log-level` + `--log-file`       |
-
-**Not supported** (use LSP trace settings instead): elixir-ls, gleam, intelephense, jdtls, kotlin-lsp, nixd, ocaml-lsp, pyright, vtsls, yaml-language-server
 
 ## License
 

--- a/bash-language-server/.claude-plugin/plugin.json
+++ b/bash-language-server/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/bash-language-server/.lsp.json
+++ b/bash-language-server/.lsp.json
@@ -7,11 +7,6 @@
       ".bash": "shellscript",
       ".zsh": "shellscript",
       ".ksh": "shellscript"
-    },
-    "loggingConfig": {
-      "env": {
-        "BASH_IDE_LOG_LEVEL": "debug"
-      }
     }
   }
 }

--- a/clangd/.claude-plugin/plugin.json
+++ b/clangd/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/clangd/.lsp.json
+++ b/clangd/.lsp.json
@@ -11,9 +11,6 @@
       ".hxx": "cpp",
       ".m": "objective-c",
       ".mm": "objective-cpp"
-    },
-    "loggingConfig": {
-      "args": ["--log=verbose"]
     }
   }
 }

--- a/clojure-lsp/.claude-plugin/plugin.json
+++ b/clojure-lsp/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/clojure-lsp/.lsp.json
+++ b/clojure-lsp/.lsp.json
@@ -6,9 +6,6 @@
       ".cljs": "clojurescript",
       ".cljc": "clojure",
       ".edn": "edn"
-    },
-    "loggingConfig": {
-      "args": ["--trace-level", "verbose"]
     }
   }
 }

--- a/dart-analyzer/.claude-plugin/plugin.json
+++ b/dart-analyzer/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/dart-analyzer/.lsp.json
+++ b/dart-analyzer/.lsp.json
@@ -4,9 +4,6 @@
     "args": ["language-server"],
     "extensionToLanguage": {
       ".dart": "dart"
-    },
-    "loggingConfig": {
-      "args": ["--instrumentation-log-file", "${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }

--- a/elixir-ls/.claude-plugin/plugin.json
+++ b/elixir-ls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/gleam/.claude-plugin/plugin.json
+++ b/gleam/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/gopls/.claude-plugin/plugin.json
+++ b/gopls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/gopls/.lsp.json
+++ b/gopls/.lsp.json
@@ -3,9 +3,6 @@
     "command": "gopls",
     "extensionToLanguage": {
       ".go": "go"
-    },
-    "loggingConfig": {
-      "args": ["-rpc.trace", "-logfile", "${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }

--- a/intelephense/.claude-plugin/plugin.json
+++ b/intelephense/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/jdtls/.claude-plugin/plugin.json
+++ b/jdtls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/kotlin-lsp/.claude-plugin/plugin.json
+++ b/kotlin-lsp/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/lua-language-server/.claude-plugin/plugin.json
+++ b/lua-language-server/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/lua-language-server/.lsp.json
+++ b/lua-language-server/.lsp.json
@@ -3,9 +3,6 @@
     "command": "lua-language-server",
     "extensionToLanguage": {
       ".lua": "lua"
-    },
-    "loggingConfig": {
-      "args": ["--loglevel=trace", "--logpath=${CLAUDE_PLUGIN_LSP_LOG_DIR}"]
     }
   }
 }

--- a/nixd/.claude-plugin/plugin.json
+++ b/nixd/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/ocaml-lsp/.claude-plugin/plugin.json
+++ b/ocaml-lsp/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/omnisharp/.claude-plugin/plugin.json
+++ b/omnisharp/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/omnisharp/.lsp.json
+++ b/omnisharp/.lsp.json
@@ -5,9 +5,6 @@
     "extensionToLanguage": {
       ".cs": "csharp",
       ".csx": "csharp"
-    },
-    "loggingConfig": {
-      "args": ["-v"]
     }
   }
 }

--- a/pyright/.claude-plugin/plugin.json
+++ b/pyright/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/rust-analyzer/.claude-plugin/plugin.json
+++ b/rust-analyzer/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/rust-analyzer/.lsp.json
+++ b/rust-analyzer/.lsp.json
@@ -3,12 +3,6 @@
     "command": "rust-analyzer",
     "extensionToLanguage": {
       ".rs": "rust"
-    },
-    "loggingConfig": {
-      "env": {
-        "RA_LOG": "info",
-        "RA_LOG_FILE": "${CLAUDE_PLUGIN_LSP_LOG_FILE}"
-      }
     }
   }
 }

--- a/solargraph/.claude-plugin/plugin.json
+++ b/solargraph/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/solargraph/.lsp.json
+++ b/solargraph/.lsp.json
@@ -6,11 +6,6 @@
       ".rb": "ruby",
       ".rake": "ruby",
       ".gemspec": "ruby"
-    },
-    "loggingConfig": {
-      "env": {
-        "SOLARGRAPH_LOG": "debug"
-      }
     }
   }
 }

--- a/sourcekit-lsp/.claude-plugin/plugin.json
+++ b/sourcekit-lsp/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/sourcekit-lsp/.lsp.json
+++ b/sourcekit-lsp/.lsp.json
@@ -4,9 +4,6 @@
     "args": ["sourcekit-lsp"],
     "extensionToLanguage": {
       ".swift": "swift"
-    },
-    "loggingConfig": {
-      "args": ["--log-level", "debug"]
     }
   }
 }

--- a/terraform-ls/.claude-plugin/plugin.json
+++ b/terraform-ls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/terraform-ls/.lsp.json
+++ b/terraform-ls/.lsp.json
@@ -5,12 +5,6 @@
     "extensionToLanguage": {
       ".tf": "terraform",
       ".tfvars": "terraform-vars"
-    },
-    "loggingConfig": {
-      "env": {
-        "TF_LOG": "DEBUG",
-        "TF_LOG_PATH": "${CLAUDE_PLUGIN_LSP_LOG_FILE}"
-      }
     }
   }
 }

--- a/vtsls/.claude-plugin/plugin.json
+++ b/vtsls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/yaml-language-server/.claude-plugin/plugin.json
+++ b/yaml-language-server/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/zls/.claude-plugin/plugin.json
+++ b/zls/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Jan Kott"
   },
-  "hooks": "./hooks/hooks.json",
-  "lspServers": "./.lsp.json"
+  "license": "MIT",
+  "repository": "https://github.com/boostvolt/claude-code-lsps",
+  "homepage": "https://github.com/boostvolt/claude-code-lsps"
 }

--- a/zls/.lsp.json
+++ b/zls/.lsp.json
@@ -4,9 +4,6 @@
     "extensionToLanguage": {
       ".zig": "zig",
       ".zon": "zig"
-    },
-    "loggingConfig": {
-      "args": ["--log-level=debug", "--log-file=${CLAUDE_PLUGIN_LSP_LOG_FILE}"]
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR enhances plugin metadata and removes unsupported configuration that causes validation errors in Claude Code 2.1.1.

### Changes

1. **Removed redundant configuration** - Removed `hooks` and `lspServers` references from all plugin.json files since these are auto-discovered from default locations
2. **Enhanced metadata** - Added `license`, `repository`, and `homepage` fields to:
   - All 22 plugin.json files
   - Marketplace metadata
3. **Fixed name mismatch** - Corrected `kotlin-language-server` → `kotlin-lsp` in marketplace.json to match actual directory name
4. **Removed loggingConfig** - Removed `loggingConfig` blocks from 12 .lsp.json files to fix validation errors in Claude Code 2.1.1
5. **Documentation cleanup** - Updated README and CLAUDE.md to reflect changes

### Why loggingConfig was removed

Despite being documented in the official Claude Code plugin reference, `loggingConfig` causes LSP config validation failures in Claude Code 2.1.1:

```
Error: LSP config validation failed for .lsp.json in plugin <name>
```

This appears to be a gap between documentation and implementation. Removed to ensure all plugins load successfully.

### Files changed

- 36 files modified
- Net reduction of 54 lines

## Test plan

- [ ] Verify all plugins load without validation errors
- [ ] Confirm LSP servers start correctly for each language
- [ ] Check plugin marketplace displays updated metadata