### PR TITLE
fix(kotlin-lsp): pass --stdio so server runs in stdio mode

### DIFF
--- a/kotlin-lsp/.lsp.json
+++ b/kotlin-lsp/.lsp.json
@@ -1,6 +1,7 @@
 {
   "kotlin": {
     "command": "kotlin-lsp",
+    "args": ["--stdio"],
     "extensionToLanguage": {
       ".kt": "kotlin",
       ".kts": "kotlin"


### PR DESCRIPTION
## Summary
- Adds `args: ["--stdio"]` to `kotlin-lsp/.lsp.json` so the LSP launches in stdio mode rather than its default TCP socket mode.

Without this, JetBrains' `kotlin-lsp` binary listens on `127.0.0.1:9999` and never reads from stdin — Claude Code's LSP bridge sends `initialize` over stdio, gets no reply, and the server hangs in a `starting` state indefinitely.

Fixes #32. Verified against `JetBrains/utils/kotlin-lsp` (LS-262.4739.0) on macOS arm64 — patched a local install, restarted Claude Code, ran `documentSymbol` against a real `.kt` file and got results back in ~7s (spawn + indexing). Spawned process argv now correctly reads `kotlin-lsp --stdio`.

## Test plan
- [ ] Install the plugin via `/plugin` and restart Claude Code
- [ ] Open a `.kt` file
- [ ] Trigger any LSP operation (e.g. `documentSymbol`); confirm it returns rather than hanging
- [ ] `ps -axo pid,comm,args | grep kotlin-lsp` shows `kotlin-lsp --stdio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)