### PR TITLE
feat: add Astro LSP plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,17 @@
   },
   "plugins": [
     {
+      "name": "astro-lsp",
+      "version": "1.0.0",
+      "source": "./astro_lsp",
+      "description": "Astro language server",
+      "category": "development",
+      "tags": ["astro", "lsp"],
+      "author": {
+        "name": "synxn1o"
+      }
+    },
+    {
       "name": "bash-language-server",
       "version": "1.0.0",
       "source": "./bash-language-server",

--- a/astro_lsp/.claude-plugin/plugin.json
+++ b/astro_lsp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "astro-lsp",
+  "description": "Astro language server for .astro files",
+  "version": "1.0.0",
+  "author": {
+    "name": "synxn1o"
+  },
+  "license": "MIT"
+}

--- a/astro_lsp/.lsp.json
+++ b/astro_lsp/.lsp.json
@@ -1,0 +1,14 @@
+{
+  "astro": {
+    "command": "astro-ls",
+    "args": ["--stdio"],
+    "extensionToLanguage": {
+      ".astro": "astro"
+    },
+    "initializationOptions": {
+      "typescript": {
+        "tsdk": "node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/astro_lsp/README.md
+++ b/astro_lsp/README.md
@@ -1,0 +1,40 @@
+# astro-lsp
+
+Astro language server for Claude Code, providing code intelligence features for `.astro` files.
+
+## Supported Extensions
+`.astro`
+
+## Installation
+
+Install the Astro language server globally via npm:
+
+```bash
+npm install -g @astrojs/language-server
+```
+
+Or with yarn:
+
+```bash
+yarn global add @astrojs/language-server
+```
+
+## Usage
+
+1. Install the plugin in Claude Code:
+   ```
+   /plugin install astro-lsp@claude-code-lsps
+   ```
+
+2. Open any `.astro` file in Claude Code
+
+3. The Astro language server will automatically start and provide:
+   - Diagnostics (errors, warnings)
+   - Completions
+   - Hover information
+   - Go-to-definition
+   - Find references
+
+## More Information
+- [@astrojs/language-server on npm](https://www.npmjs.com/package/@astrojs/language-server)
+- [GitHub Repository](https://github.com/withastro/astro/tree/main/packages/language-tools/language-server)

--- a/astro_lsp/hooks/check-astro-ls.sh
+++ b/astro_lsp/hooks/check-astro-ls.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if astro-ls is installed and available in PATH
+
+if command -v astro-ls &> /dev/null; then
+    exit 0
+fi
+
+# Check if npm is available
+if ! command -v npm &> /dev/null; then
+    echo "[astro-ls] npm is not installed. Please install Node.js first from https://nodejs.org/"
+    echo "           Then run: npm install -g @astrojs/language-server"
+    exit 0
+fi
+
+# npm is installed but astro-ls is not - install it
+echo "[astro-ls] Installing @astrojs/language-server..."
+npm install -g @astrojs/language-server
+
+if command -v astro-ls &> /dev/null; then
+    echo "[astro-ls] Installed successfully"
+else
+    echo "[astro-ls] Failed to install. Please run manually:"
+    echo "           npm install -g @astrojs/language-server"
+fi
+
+exit 0

--- a/astro_lsp/hooks/hooks.json
+++ b/astro_lsp/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Check for astro-ls installation on session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/check-astro-ls.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add LSP plugin for `.astro` files using `@astrojs/language-server`
- Includes auto-install hook (`hooks/check-astro-ls.sh`) that runs on session start
- `.lsp.json` with `typescript.tsdk` initialization option (required by astro-ls)
- Registered in marketplace.json

## Plugin structure
```
astro_lsp/
├── .claude-plugin/
│   └── plugin.json
├── .lsp.json
├── hooks/
│   ├── hooks.json
│   └── check-astro-ls.sh
└── README.md
```

## Tested
- `documentSymbol` — returns Props interface, variables, HTML elements, CSS rules
- `hover` — returns type info for Astro component props

🤖 Generated with [Claude Code](https://claude.ai/code)